### PR TITLE
Switch from branch to default-branch

### DIFF
--- a/org.qbittorrent.qBittorrent.yaml
+++ b/org.qbittorrent.qBittorrent.yaml
@@ -1,5 +1,5 @@
 app-id: org.qbittorrent.qBittorrent
-branch: stable
+default-branch: stable
 runtime: org.kde.Platform
 sdk: org.kde.Sdk
 runtime-version: '5.13'


### PR DESCRIPTION
Flathub will automatically set stable branch for all official builds. Hardcoding branch in manifest means all test builds from PRs will use stable branch instead of test one which makes impossible to install them alongside official version.