### PR TITLE
Use boost::system in header form

### DIFF
--- a/org.qbittorrent.qBittorrent.yaml
+++ b/org.qbittorrent.qBittorrent.yaml
@@ -29,7 +29,7 @@ modules:
   - name: boost
     buildsystem: simple
     build-commands:
-      - ./bootstrap.sh --prefix=/app --with-libraries=system
+      - ./bootstrap.sh --prefix=/app --with-libraries=headers
       - ./b2 install variant=release link=shared runtime-link=shared cxxflags="$CXXFLAGS" linkflags="$LDFLAGS" -j $FLATPAK_BUILDER_N_JOBS
     sources:
       - type: archive


### PR DESCRIPTION
So there is no need to build it anymore.