### PR TITLE
Update QBitTorrent to 4.3.5

### DIFF
--- a/org.qbittorrent.qBittorrent.yaml
+++ b/org.qbittorrent.qBittorrent.yaml
@@ -34,7 +34,7 @@ modules:
       - ./b2 install variant=release link=shared runtime-link=shared cxxflags="$CXXFLAGS" linkflags="$LDFLAGS" -j $FLATPAK_BUILDER_N_JOBS
     sources:
       - type: archive
-        url: https://dl.bintray.com/boostorg/release/1.75.0/source/boost_1_75_0.tar.bz2
+        url: https://boostorg.jfrog.io/artifactory/main/release/1.75.0/source/boost_1_75_0.tar.bz2
         sha256: 953db31e016db7bb207f11432bef7df100516eeb746843fa0486a222e3fd49cb
 
   - name: libtorrent
@@ -52,8 +52,7 @@ modules:
     builddir: true
     config-opts:
       - -DCMAKE_BUILD_TYPE=RelWithDebInfo
-      - -DQBT_VER_STATUS=""
     sources:
       - type: archive
-        url: https://downloads.sourceforge.net/project/qbittorrent/qbittorrent/qbittorrent-4.3.4.1/qbittorrent-4.3.4.1.tar.xz
-        sha256: 4bb87bed614dcfbaeb07f70d90b4e09c628aacad4a1ea7972cd2d77ed8c320f1
+        url: https://github.com/qbittorrent/qBittorrent/archive/refs/tags/release-4.3.5.tar.gz
+        sha256: 83b6165f9f969406a2daabc7f49bbdc79aa6840c1e707cbade97eeb15a4907f3


### PR DESCRIPTION
Boost mirror changed following Upstream's directions