### PR TITLE
Fix flathub linter issues

### DIFF
--- a/org.qbittorrent.qBittorrent.yaml
+++ b/org.qbittorrent.qBittorrent.yaml
@@ -8,7 +8,7 @@ rename-icon: qbittorrent
 copy-icon: true
 finish-args:
   - --socket=wayland
-  - --socket=x11
+  - --socket=fallback-x11
   - --share=ipc
   - --share=network
   - --device=dri
@@ -18,7 +18,7 @@ finish-args:
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.freedesktop.PowerManagement
   - --talk-name=org.gnome.SessionManager
-  - --own-name=org.kde.StatusNotifierItem-2-2
+  - --own-name=org.kde.*
 cleanup:
   - /include
   - /lib/cmake


### PR DESCRIPTION
This fixes below errors/warnings:

```
{
    "errors": [
        "finish-args-broken-kde-tray-permission"
    ],
    "warnings": [
        "finish-args-contains-both-x11-and-wayland"
    ]
}
```