### PR TITLE
Fix LTO build

### DIFF
--- a/org.qbittorrent.qBittorrent.yaml
+++ b/org.qbittorrent.qBittorrent.yaml
@@ -43,10 +43,8 @@ modules:
     config-opts:
       - -DCMAKE_AR=/usr/bin/gcc-ar
       - -DCMAKE_BUILD_TYPE=RelWithDebInfo
-      - -DCMAKE_C_FLAGS=-flto=auto
-      - -DCMAKE_CXX_FLAGS=-flto=auto
       - -DCMAKE_RANLIB=/usr/bin/gcc-ranlib
-      - -DCMAKE_SHARED_LINKER_FLAGS=-flto=auto
+      - -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON
       - -Ddeprecated-functions=OFF
     sources:
       - type: archive
@@ -59,8 +57,7 @@ modules:
     config-opts:
       - -DCMAKE_AR=/usr/bin/gcc-ar
       - -DCMAKE_BUILD_TYPE=RelWithDebInfo
-      - -DCMAKE_CXX_FLAGS=-flto=auto
-      - -DCMAKE_EXE_LINKER_FLAGS=-flto=auto
+      - -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON
       - -DCMAKE_RANLIB=/usr/bin/gcc-ranlib
     sources:
       - type: archive


### PR DESCRIPTION
The https://github.com/flathub/org.qbittorrent.qBittorrent/pull/96 (Build with LTO) change has unwanted side-effect - it overwrites all default cflags/ldflags that come from flatpak runtime (mostly binary hardening stuff).

Using `CMAKE_INTERPROCEDURAL_OPTIMIZATION` variable is canonical approach for using LTO with cmake and it results with `-flto=auto` being appended to the default build flag set instead of replacing them.

cc: @Chocobo1