### PR TITLE
Build libtorrent as a static library

### DIFF
--- a/org.qbittorrent.qBittorrent.yaml
+++ b/org.qbittorrent.qBittorrent.yaml
@@ -23,9 +23,11 @@ cleanup:
   - /include
   - /lib/cmake
   - /lib/pkgconfig
+  - /lib/*.a
   - /lib/*.la
   - /share/cmake
   - /share/man
+
 modules:
   - name: boost
     buildsystem: simple
@@ -41,6 +43,7 @@ modules:
     buildsystem: cmake-ninja
     builddir: true
     config-opts:
+      - -DBUILD_SHARED_LIBS=OFF
       - -DCMAKE_BUILD_TYPE=RelWithDebInfo
       - -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON
       - -Ddeprecated-functions=OFF
@@ -48,6 +51,8 @@ modules:
       - type: archive
         url: https://github.com/arvidn/libtorrent/releases/download/v1.2.18/libtorrent-rasterbar-1.2.18.tar.gz
         sha256: fef2b6817de4e6d960e019c27f21daf27bc2468a81d9e028a19d45d61456fa72
+      - type: patch
+        path: static_lib.patch
 
   - name: qbittorrent
     buildsystem: cmake-ninja

--- a/static_lib.patch
+++ b/static_lib.patch
@@ -1,0 +1,26 @@
+From a7be63c0f36371fcba020254c38f93710dd6df4b Mon Sep 17 00:00:00 2001
+From: Chocobo1 <Chocobo1@users.noreply.github.com>
+Date: Tue, 3 Jan 2023 19:25:29 +0800
+Subject: [PATCH] Don't require dependencies to be static libraries
+
+when libtorrent itself is being built as a static library.
+---
+ CMakeLists.txt | 5 -----
+ 1 file changed, 5 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 627b3e41e1..a4b7c02f1d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -501,11 +501,6 @@ if(static_runtime)
+ 	set(OPENSSL_MSVC_STATIC_RT ON)
+ endif()
+ 
+-if (NOT BUILD_SHARED_LIBS)
+-	set(Boost_USE_STATIC_LIBS ON)
+-	set(OPENSSL_USE_STATIC_LIBS ON)
+-endif()
+-
+ add_library(torrent-rasterbar
+ 	${sources}
+ 	${libtorrent_include_files}


### PR DESCRIPTION
This should improve LTO ability to trim off unused code sections.
Patch is taken from upstream: https://github.com/arvidn/libtorrent/commit/a7be63c0f36371fcba020254c38f93710dd6df4b