### PR TITLE
Remove overly broad ownership permission

### DIFF
--- a/org.qbittorrent.qBittorrent.yaml
+++ b/org.qbittorrent.qBittorrent.yaml
@@ -18,7 +18,6 @@ finish-args:
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.freedesktop.PowerManagement
   - --talk-name=org.gnome.SessionManager
-  - --own-name=org.kde.*
 cleanup:
   - /include
   - /lib/cmake


### PR DESCRIPTION
As of recent Qt versions this is no longer needed.