### PR TITLE
Allow qbt to control system power (#107)

### DIFF
--- a/org.qbittorrent.qBittorrent.yaml
+++ b/org.qbittorrent.qBittorrent.yaml
@@ -14,6 +14,8 @@ finish-args:
   - --share=network
   - --socket=fallback-x11
   - --socket=wayland
+  - --system-talk-name=org.freedesktop.login1
+  - --system-talk-name=org.freedesktop.UPower
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.freedesktop.PowerManagement
   - --talk-name=org.gnome.SessionManager


### PR DESCRIPTION
qbt provides functionality that requires it:
https://github.com/qbittorrent/qBittorrent/blob/e37661d53a0249548238a89d41736260998348f6/src/base/utils/misc.cpp#L192-L250