### PR TITLE
Improve version checker script for boost

### DIFF
--- a/org.qbittorrent.qBittorrent.yaml
+++ b/org.qbittorrent.qBittorrent.yaml
@@ -41,8 +41,8 @@ modules:
         sha256: 71feeed900fbccca04a3b4f2f84a7c217186f28a940ed8b7ed4725986baf99fa
         x-checker-data:
           type: html
-          url: https://boostorg.jfrog.io/artifactory/main/release/
-          version-pattern: <a href="([\d\.]+)\/">
+          url: https://www.boost.org/feed/downloads.rss
+          version-pattern: <item><title>Version ([\d\.]+)</title>
           url-template: https://boostorg.jfrog.io/artifactory/main/release/${version}/source/boost_${major}_${minor}_${patch}.tar.bz2
 
   - name: libtorrent

--- a/org.qbittorrent.qBittorrent.yaml
+++ b/org.qbittorrent.qBittorrent.yaml
@@ -57,7 +57,7 @@ modules:
       - type: git
         url: https://github.com/arvidn/libtorrent.git
         branch: RC_1_2
-        commit: d22612ca1bf41fb120b3f83e479d1aab99dcc15e
+        commit: 93ecd2ff3b1766c16fef65b62b36f623654dc1f3
         #x-checker-data:
         #  type: json
         #  url: https://api.github.com/repos/arvidn/libtorrent/releases


### PR DESCRIPTION
To avoid mistreating boost RC releases as stable releases.