### PR TITLE
Update KDE sdk to latest used by upstream

### DIFF
--- a/org.qbittorrent.qBittorrent.yaml
+++ b/org.qbittorrent.qBittorrent.yaml
@@ -2,7 +2,7 @@ app-id: org.qbittorrent.qBittorrent
 default-branch: stable
 runtime: org.kde.Platform
 sdk: org.kde.Sdk
-runtime-version: 5.15-22.08
+runtime-version: 5.15-23.08
 command: qbittorrent
 rename-icon: qbittorrent
 copy-icon: true


### PR DESCRIPTION
I have updated the SDK to the latest that AppImage uses. Should be tested if everything works correctly.
