### PR TITLE
Switch to .gz format for boost archive

### DIFF
--- a/org.qbittorrent.qBittorrent.yaml
+++ b/org.qbittorrent.qBittorrent.yaml
@@ -37,13 +37,13 @@ modules:
         linkflags="$LDFLAGS" -j $FLATPAK_BUILDER_N_JOBS
     sources:
       - type: archive
-        url: https://boostorg.jfrog.io/artifactory/main/release/1.83.0/source/boost_1_83_0.tar.bz2
-        sha256: 6478edfe2f3305127cffe8caf73ea0176c53769f4bf1585be237eb30798c3b8e
+        url: https://boostorg.jfrog.io/artifactory/main/release/1.83.0/source/boost_1_83_0.tar.gz
+        sha256: c0685b68dd44cc46574cce86c4e17c0f611b15e195be9848dfd0769a0a207628
         x-checker-data:
           type: html
           url: https://www.boost.org/feed/downloads.rss
           version-pattern: <item><title>Version ([\d\.]+)<\/title>
-          url-template: https://boostorg.jfrog.io/artifactory/main/release/${version}/source/boost_${major}_${minor}_${patch}.tar.bz2
+          url-template: https://boostorg.jfrog.io/artifactory/main/release/${version}/source/boost_${major}_${minor}_${patch}.tar.gz
 
   - name: libtorrent
     buildsystem: cmake-ninja


### PR DESCRIPTION
For the same reason as https://github.com/qbittorrent/qBittorrent/commit/bcfa2512902d336aabce4cad179018634c88f61c