### PR TITLE
Update boost URL

### DIFF
--- a/org.qbittorrent.qBittorrent.yaml
+++ b/org.qbittorrent.qBittorrent.yaml
@@ -36,13 +36,13 @@ modules:
         linkflags="$LDFLAGS" -j $FLATPAK_BUILDER_N_JOBS
     sources:
       - type: archive
-        url: https://boostorg.jfrog.io/artifactory/main/release/1.86.0/source/boost_1_86_0.tar.gz
+        url: https://archives.boost.io/release/1.86.0/source/boost_1_86_0.tar.gz
         sha256: 2575e74ffc3ef1cd0babac2c1ee8bdb5782a0ee672b1912da40e5b4b591ca01f
         x-checker-data:
           type: html
           url: https://www.boost.org/feed/downloads.rss
           version-pattern: <item><title>Version ([\d\.]+)<\/title>
-          url-template: https://boostorg.jfrog.io/artifactory/main/release/${version}/source/boost_${major}_${minor}_${patch}.tar.gz
+          url-template: https://archives.boost.io/release/${version}/source/boost_${major}_${minor}_${patch}.tar.gz
 
   - name: libtorrent
     buildsystem: cmake-ninja


### PR DESCRIPTION
The agreement between Boost & JFrog came to an end in December 2024.
https://github.com/boostorg/boost/issues/924