### PR TITLE
Simplify boost build flags

### DIFF
--- a/org.qbittorrent.qBittorrent.yaml
+++ b/org.qbittorrent.qBittorrent.yaml
@@ -31,9 +31,8 @@ modules:
   - name: boost
     buildsystem: simple
     build-commands:
-      - ./bootstrap.sh --prefix=/app --with-libraries=headers
-      - ./b2 install variant=release link=shared runtime-link=shared cxxflags="$CXXFLAGS"
-        linkflags="$LDFLAGS" -j $FLATPAK_BUILDER_N_JOBS
+      - ./bootstrap.sh --prefix=/app
+      - ./b2 install --with-headers cxxflags="$CXXFLAGS" linkflags="$LDFLAGS" -j $FLATPAK_BUILDER_N_JOBS
     sources:
       - type: archive
         url: https://archives.boost.io/release/1.86.0/source/boost_1_86_0.tar.gz


### PR DESCRIPTION
The stripped flags are not relevant since it is using header-only mode.