### PR TITLE
Pause boost update

### DIFF
--- a/org.qbittorrent.qBittorrent.yaml
+++ b/org.qbittorrent.qBittorrent.yaml
@@ -37,11 +37,11 @@ modules:
       - type: archive
         url: https://archives.boost.io/release/1.86.0/source/boost_1_86_0.tar.gz
         sha256: 2575e74ffc3ef1cd0babac2c1ee8bdb5782a0ee672b1912da40e5b4b591ca01f
-        x-checker-data:
-          type: html
-          url: https://www.boost.org/feed/downloads.rss
-          version-pattern: <item><title>Version ([\d\.]+)<\/title>
-          url-template: https://archives.boost.io/release/${version}/source/boost_${major}_${minor}_${patch}.tar.gz
+        #x-checker-data:
+        #  type: html
+        #  url: https://www.boost.org/feed/downloads.rss
+        #  version-pattern: <item><title>Version ([\d\.]+)<\/title>
+        #  url-template: https://archives.boost.io/release/${version}/source/boost_${major}_${minor}_${patch}.tar.gz
 
   - name: libtorrent
     buildsystem: cmake-ninja


### PR DESCRIPTION
libtorrent 1.2.x is incompatible with boost newer than 1.86.