### PR TITLE
Add qbt-nox binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,18 @@
 To install, simply click the above `Get it on Flathub` button and follow the instructions. \
 In reality, 2 branches are provided:
 1. Stable (default) \
-   This follows the regular stable release of qBittorrent (with GUI).
+   This follows the regular stable release of qBittorrent.
    * To install:
      ```shell
      flatpak install flathub org.qbittorrent.qBittorrent
      ```
-   * To run:
+   * To run the default GUI version:
      ```shell
      flatpak run org.qbittorrent.qBittorrent
+     ```
+   * To run the nox version:
+     ```shell
+     flatpak run --command=qbittorrent-nox org.qbittorrent.qBittorrent
      ```
 
 2. Beta \
@@ -28,9 +32,13 @@ In reality, 2 branches are provided:
      ```shell
      flatpak install flathub-beta org.qbittorrent.qBittorrent
      ```
-   * To run:
+   * To run GUI version:
      ```shell
      flatpak run org.qbittorrent.qBittorrent//beta
+     ```
+   * To run nox version:
+     ```shell
+     flatpak run --command=qbittorrent-nox org.qbittorrent.qBittorrent//beta
      ```
    * Set stable version as the default when you invoke `flatpak run org.qbittorrent.qBittorrent`
      ```shell

--- a/org.qbittorrent.qBittorrent.yaml
+++ b/org.qbittorrent.qBittorrent.yaml
@@ -62,11 +62,27 @@ modules:
           commit-query: .commit.sha
 
   - name: qbittorrent
-    buildsystem: cmake-ninja
-    builddir: true
-    config-opts:
-      - -DCMAKE_BUILD_TYPE=RelWithDebInfo
-      - -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON
+    buildsystem: simple
+    build-commands:
+      # GUI build
+      - cmake
+        -B build
+        -G Ninja
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo
+        -DCMAKE_INSTALL_PREFIX="/app"
+        -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON
+      - cmake --build build
+      - cmake --install build
+      # nox build
+      - cmake
+        -B build-nox
+        -G Ninja
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo
+        -DCMAKE_INSTALL_PREFIX="/app"
+        -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON
+        -DGUI=OFF
+      - cmake --build build-nox
+      - cmake --install build-nox
     sources:
       - type: archive
         url: https://github.com/qbittorrent/qBittorrent/archive/refs/tags/release-5.1.0.tar.gz


### PR DESCRIPTION
Note that the qbt-nox is sort of an additional binary so I do not intend to provide .desktop file or .metainfo.xml for it. Also the target audiences should be without a desktop environment so these files will be useless anyway.

Closes #70.