### PR TITLE
Fix missing tray icon on Ubuntu MATE and Trisquel

### DIFF
--- a/org.qbittorrent.qBittorrent.yaml
+++ b/org.qbittorrent.qBittorrent.yaml
@@ -13,6 +13,7 @@ finish-args:
   - --socket=wayland
   - --system-talk-name=org.freedesktop.login1
   - --system-talk-name=org.freedesktop.UPower
+  - --talk-name=org.ayatana.indicator.application  # for Ubuntu MATE and Trisquel
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.freedesktop.PowerManagement
   - --talk-name=org.gnome.SessionManager


### PR DESCRIPTION
Solves
* https://github.com/flathub/org.qbittorrent.qBittorrent/issues/204